### PR TITLE
Fix/Use TensorFlow Interpreter If Available (Fallback to TFLite Runtime)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,10 @@ test-watch:    ## Run tests and generate coverage report.
 test:    ## Run tests and generate coverage report.
 	$(ENV_PREFIX)pytest -s -vvv -l --tb=long --maxfail=1 tests/
 
+.PHONY: nox
+nox:
+	$(ENV_PREFIX)nox
+
 .PHONY: coverage
 coverage:    ## Run tests and generate coverage report.
 	$(ENV_PREFIX)coverage run -m pytest tests/

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,10 @@ test:    ## Run tests and generate coverage report.
 nox:
 	$(ENV_PREFIX)nox
 
+.PHONY: nox-lint
+nox-lint:
+	$(ENV_PREFIX)nox -s lint
+
 .PHONY: coverage
 coverage:    ## Run tests and generate coverage report.
 	$(ENV_PREFIX)coverage run -m pytest tests/

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+import os
+
+import nox
+
+
+def ensurepath():
+    rye_home = os.getenv("RYE_HOME")
+    rye_py = Path(rye_home) / "py" if rye_home else Path.home() / ".rye" / "py"
+
+    for py_dir in rye_py.iterdir():
+        bin_dir = py_dir / "bin"
+        print(bin_dir)
+        os.environ["PATH"] = f"{bin_dir}:{os.environ['PATH']}"
+
+
+ensurepath()
+
+
+@nox.session(python=["3.9", "3.10", "3.11"], venv_backend="uv")
+def test_tflite_only(session):
+    session.install(".[tflite]")
+    session.install("pytest")
+    session.install("pytest-mock")
+    session.run("pytest", "-m", "tflite")
+
+
+@nox.session(python=["3.9", "3.10", "3.11"], venv_backend="uv")
+def test_tensorflow_only(session):
+    session.install(".[tensorflow]")
+    session.install("pytest")
+    session.install("pytest-mock")
+    session.run("pytest", "-m", "tensorflow")

--- a/noxfile.py
+++ b/noxfile.py
@@ -31,3 +31,11 @@ def test_tensorflow_only(session):
     session.install("pytest")
     session.install("pytest-mock")
     session.run("pytest", "-m", "tensorflow")
+
+@nox.session(python=["3.9", "3.10", "3.11"], venv_backend="uv")
+def lint(session):
+    session.install(".[all]")
+    session.install("pyright")
+    session.install("ruff")
+    session.run("pyright", "src")
+    session.run("ruff", "check", "src")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,10 +19,10 @@ license = { text = "MIT" }
 
 [project.optional-dependencies]
 tensorflow = ["tensorflow>=2.0", "tensorflow-hub>=0.16.1"]
-tflite = ["tflite>=2.0", "tflite-runtime>=2.14.0"]
+tflite = ["tflite-runtime>=2.14.0", "numpy<2"]
 birdnet = ["audioclass[tflite]"]
 perch = ["audioclass[tensorflow]"]
-all = ["audioclass[birdnet]", "audioclass[perch]"]
+all = ["audioclass[tensorflow]"]
 
 [build-system]
 requires = ["hatchling"]
@@ -46,6 +46,7 @@ dev-dependencies = [
     "mkdocs>=1.6.0",
     "mkdocstrings[python]>=0.25.1",
     "mkdocs-material>=9.5.25",
+    "nox>=2024.4.15",
 ]
 
 [tool.ruff]
@@ -72,3 +73,6 @@ pythonVersion = "3.9"
 branch = true
 source = ["src/audioclass"]
 command_line = "-m pytest"
+
+[tool.pytest.ini_options]
+markers = ["tflite", "tensorflow"]

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -15,6 +15,8 @@ absl-py==2.1.0
     # via tensorflow
 annotated-types==0.7.0
     # via pydantic
+argcomplete==3.4.0
+    # via nox
 astunparse==1.6.3
     # via tensorflow
 babel==2.15.0
@@ -34,17 +36,22 @@ click==8.1.7
 colorama==0.4.6
     # via griffe
     # via mkdocs-material
+colorlog==6.8.2
+    # via nox
 coverage==7.5.3
     # via pytest-cov
 cython==3.0.10
     # via soundevent
+distlib==0.3.8
+    # via virtualenv
 dnspython==2.6.1
     # via email-validator
 email-validator==2.1.1
     # via soundevent
+filelock==3.15.1
+    # via virtualenv
 flatbuffers==24.3.25
     # via tensorflow
-    # via tflite
 gast==0.5.4
     # via tensorflow
 ghp-import==2.1.0
@@ -116,6 +123,7 @@ netcdf4==1.6.5
     # via audioclass
 nodeenv==1.9.0
     # via pyright
+nox==2024.4.15
 numpy==1.24.4
     # via cftime
     # via h5py
@@ -129,7 +137,6 @@ numpy==1.24.4
     # via tensorboard
     # via tensorflow
     # via tensorflow-hub
-    # via tflite
     # via tflite-runtime
     # via xarray
 opt-einsum==3.3.0
@@ -138,6 +145,7 @@ optree==0.11.0
     # via keras
 packaging==24.0
     # via mkdocs
+    # via nox
     # via pytest
     # via tensorflow
     # via xarray
@@ -151,6 +159,7 @@ pathspec==0.12.1
 platformdirs==4.2.2
     # via mkdocs-get-deps
     # via mkdocstrings
+    # via virtualenv
 pluggy==1.5.0
     # via pytest
 protobuf==4.25.3
@@ -232,8 +241,6 @@ termcolor==2.4.0
     # via tensorflow
 tf-keras==2.16.0
     # via tensorflow-hub
-tflite==2.10.0
-    # via audioclass
 tflite-runtime==2.14.0
     # via audioclass
 tqdm==4.66.4
@@ -247,6 +254,8 @@ tzdata==2024.1
     # via pandas
 urllib3==2.2.1
     # via requests
+virtualenv==20.26.2
+    # via nox
 watchdog==4.0.1
     # via mkdocs
 werkzeug==3.0.3

--- a/requirements.lock
+++ b/requirements.lock
@@ -34,7 +34,6 @@ email-validator==2.1.1
     # via soundevent
 flatbuffers==24.3.25
     # via tensorflow
-    # via tflite
 gast==0.5.4
     # via tensorflow
 google-pasta==0.2.0
@@ -80,7 +79,6 @@ numpy==1.24.4
     # via tensorboard
     # via tensorflow
     # via tensorflow-hub
-    # via tflite
     # via tflite-runtime
     # via xarray
 opt-einsum==3.3.0
@@ -146,8 +144,6 @@ termcolor==2.4.0
     # via tensorflow
 tf-keras==2.16.0
     # via tensorflow-hub
-tflite==2.10.0
-    # via audioclass
 tflite-runtime==2.14.0
     # via audioclass
 tqdm==4.66.4

--- a/src/audioclass/models/birdnet.py
+++ b/src/audioclass/models/birdnet.py
@@ -29,10 +29,10 @@ from pathlib import Path
 from typing import List, Optional, Union
 
 from soundevent import data
-from tflite_runtime.interpreter import Interpreter
 
 from audioclass.constants import DEFAULT_THRESHOLD
 from audioclass.models.tflite import (
+    Interpreter,
     Signature,
     TFLiteModel,
     load_model,
@@ -116,7 +116,7 @@ class BirdNET(TFLiteModel):
         tags = load_tags(labels_path, common_name=common_name)
         return cls(
             interpreter=interpreter,
-            signature=get_signature(interpreter),
+            signature=get_signature(interpreter),  # type: ignore
             tags=tags,
             confidence_threshold=confidence_threshold,
             samplerate=samplerate,

--- a/src/audioclass/models/tflite.py
+++ b/src/audioclass/models/tflite.py
@@ -20,7 +20,7 @@ from audioclass.utils import flat_sigmoid
 try:
     from tensorflow._api.v2.lite import Interpreter
 except ImportError:
-    from tflite_runtime.interpreter import Interpreter
+    from tflite_runtime.interpreter import Interpreter  # type: ignore
 
 __all__ = [
     "load_model",

--- a/src/audioclass/models/tflite.py
+++ b/src/audioclass/models/tflite.py
@@ -13,15 +13,20 @@ from typing import List, Optional
 import numpy as np
 from numpy.typing import DTypeLike
 from soundevent import data
-from tflite_runtime.interpreter import Interpreter
 
 from audioclass.models.base import ClipClassificationModel, ModelOutput
 from audioclass.utils import flat_sigmoid
+
+try:
+    from tensorflow._api.v2.lite import Interpreter
+except ImportError:
+    from tflite_runtime.interpreter import Interpreter
 
 __all__ = [
     "load_model",
     "Signature",
     "TFLiteModel",
+    "Interpreter",
 ]
 
 

--- a/tests/test_batch/test_tensorflow.py
+++ b/tests/test_batch/test_tensorflow.py
@@ -1,11 +1,15 @@
 from pathlib import Path
 from typing import List
 
+import pytest
+pytest.importorskip("tensorflow")
+
 import numpy as np
 from audioclass.batch.tensorflow import TFDatasetIterator
 from soundevent import data
 
 
+@pytest.mark.tensorflow
 def test_tf_iterator(recordings: List[data.Recording]):
     iterator = TFDatasetIterator(
         recordings,
@@ -20,6 +24,7 @@ def test_tf_iterator(recordings: List[data.Recording]):
         assert all(isinstance(rec, data.Recording) for rec in recordings)
 
 
+@pytest.mark.tensorflow
 def test_tf_iterator_goes_through_all_frames(
     recordings: List[data.Recording],
     durations: List[float],
@@ -47,6 +52,7 @@ def test_tf_iterator_goes_through_all_frames(
     assert frames == total_frames
 
 
+@pytest.mark.tensorflow
 def test_can_iterate_over_files_in_directory(
     audio_dir: Path,
     file_list: List[Path],

--- a/tests/test_models/test_birdnet.py
+++ b/tests/test_models/test_birdnet.py
@@ -1,16 +1,19 @@
 import datetime
 
+import pytest
 import numpy as np
 import xarray as xr
 from audioclass.models.birdnet import BirdNET
 from soundevent import data
 
 
+@pytest.mark.tflite
 def test_can_instantiate_birdnet_model_from_model_files():
     model = BirdNET.load()
     assert isinstance(model, BirdNET)
 
 
+@pytest.mark.tflite
 def test_birdnet_model_can_process_random_array():
     model = BirdNET.load(confidence_threshold=0)
     array = np.random.rand(1, 144000).astype(np.float32)
@@ -23,6 +26,7 @@ def test_birdnet_model_can_process_random_array():
     assert class_probs.shape == (1, 6522)
 
 
+@pytest.mark.tflite
 def test_birdnet_model_can_process_file(random_wav_factory):
     model = BirdNET.load()
     path = random_wav_factory(duration=10)
@@ -31,6 +35,7 @@ def test_birdnet_model_can_process_file(random_wav_factory):
     assert all(isinstance(cp, data.ClipPrediction) for cp in clip_predictions)
 
 
+@pytest.mark.tflite
 def test_birdnet_model_can_process_recording(random_wav_factory):
     model = BirdNET.load()
     path = random_wav_factory(duration=10)
@@ -40,6 +45,7 @@ def test_birdnet_model_can_process_recording(random_wav_factory):
     assert all(isinstance(cp, data.ClipPrediction) for cp in clip_predictions)
 
 
+@pytest.mark.tflite
 def test_birdnet_model_can_process_clip(random_wav_factory):
     model = BirdNET.load()
     path = random_wav_factory(duration=10)
@@ -57,6 +63,7 @@ def test_birdnet_model_can_process_clip(random_wav_factory):
     assert clip_prediction.clip.end_time == 4
 
 
+@pytest.mark.tflite
 def test_birdnet_process_clip_with_dataset_output(random_wav_factory):
     model = BirdNET.load()
     path = random_wav_factory(duration=10)
@@ -71,6 +78,7 @@ def test_birdnet_process_clip_with_dataset_output(random_wav_factory):
     assert "probabilities" in dataset
 
 
+@pytest.mark.tflite
 def test_birdnet_can_process_recording_with_metadata(random_wav_factory):
     model = BirdNET.load()
     path = random_wav_factory(duration=10)

--- a/tests/test_models/test_perch.py
+++ b/tests/test_models/test_perch.py
@@ -1,10 +1,13 @@
 import datetime
 
-import numpy as np
 import pytest
+pytest.importorskip("tensorflow")
+
+import numpy as np
 import xarray as xr
 from audioclass.models.perch import Perch
 from soundevent import data
+
 
 
 @pytest.fixture(scope="module")
@@ -12,6 +15,7 @@ def perch() -> Perch:
     return Perch.load()
 
 
+@pytest.mark.tensorflow
 def test_loaded_perch_model_has_correct_signature(perch: Perch):
     assert perch.callable is not None
     assert perch.signature is not None
@@ -22,6 +26,7 @@ def test_loaded_perch_model_has_correct_signature(perch: Perch):
     assert perch.signature.feature_name == "output_1"
 
 
+@pytest.mark.tensorflow
 def test_perch_model_can_process_random_array(perch: Perch):
     array = np.random.rand(1, 160000).astype(np.float32)
     results = perch.process_array(array)
@@ -33,6 +38,7 @@ def test_perch_model_can_process_random_array(perch: Perch):
     assert class_probs.shape == (1, 10932)
 
 
+@pytest.mark.tensorflow
 def test_perch_model_can_process_file(random_wav_factory, perch: Perch):
     path = random_wav_factory(duration=10)
     clip_predictions = perch.process_file(path)
@@ -40,6 +46,7 @@ def test_perch_model_can_process_file(random_wav_factory, perch: Perch):
     assert all(isinstance(cp, data.ClipPrediction) for cp in clip_predictions)
 
 
+@pytest.mark.tensorflow
 def test_perch_model_can_process_recording(random_wav_factory, perch: Perch):
     path = random_wav_factory(duration=10)
     recording = data.Recording.from_file(path)
@@ -48,6 +55,7 @@ def test_perch_model_can_process_recording(random_wav_factory, perch: Perch):
     assert all(isinstance(cp, data.ClipPrediction) for cp in clip_predictions)
 
 
+@pytest.mark.tensorflow
 def test_perch_model_can_process_clip(random_wav_factory, perch: Perch):
     path = random_wav_factory(duration=10)
     clip = data.Clip(
@@ -64,6 +72,7 @@ def test_perch_model_can_process_clip(random_wav_factory, perch: Perch):
     assert clip_prediction.clip.end_time == 6
 
 
+@pytest.mark.tensorflow
 def test_perch_process_clip_with_dataset_output(
     random_wav_factory, perch: Perch
 ):
@@ -79,6 +88,7 @@ def test_perch_process_clip_with_dataset_output(
     assert "probabilities" in dataset
 
 
+@pytest.mark.tensorflow
 def test_perch_can_process_recording_with_metadata(
     random_wav_factory, perch: Perch
 ):

--- a/tests/test_models/test_tflite.py
+++ b/tests/test_models/test_tflite.py
@@ -1,8 +1,7 @@
 import numpy as np
 import pytest
 from audioclass.models.birdnet import BirdNET
-from audioclass.models.tflite import Signature, process_array
-from tflite_runtime.interpreter import Interpreter
+from audioclass.models.tflite import Interpreter, Signature, process_array
 
 
 @pytest.fixture
@@ -12,7 +11,7 @@ def birdnet_model() -> BirdNET:
 
 @pytest.fixture
 def interpreter(birdnet_model: BirdNET) -> Interpreter:
-    return birdnet_model.interpreter
+    return birdnet_model.interpreter  # type: ignore
 
 
 @pytest.fixture
@@ -20,6 +19,7 @@ def signature(birdnet_model: BirdNET) -> Signature:
     return birdnet_model.signature
 
 
+@pytest.mark.tflite
 def test_process_array_can_process_1d_arrays(
     interpreter: Interpreter, signature: Signature
 ):
@@ -27,6 +27,7 @@ def test_process_array_can_process_1d_arrays(
     process_array(interpreter, signature, array)
 
 
+@pytest.mark.tflite
 def test_process_array_fails_with_incorrect_size(
     interpreter: Interpreter, signature: Signature
 ):
@@ -36,6 +37,7 @@ def test_process_array_fails_with_incorrect_size(
         process_array(interpreter, signature, array)
 
 
+@pytest.mark.tflite
 def test_process_array_fails_for_3d_array(
     interpreter: Interpreter, signature: Signature
 ):
@@ -45,6 +47,7 @@ def test_process_array_fails_for_3d_array(
         process_array(interpreter, signature, array)
 
 
+@pytest.mark.tflite
 def test_can_process_arrays_with_dynamic_batch_size(
     interpreter: Interpreter, signature: Signature
 ):


### PR DESCRIPTION
Absolutely! Here's a refined version of the pull request description, incorporating best practices for clarity and conciseness:

**Pull Request Title:** Fix/Use TensorFlow Interpreter If Available (Fallback to TFLite Runtime)

**Description:**

This pull request addresses compatibility issues encountered with the `tflite_runtime` package, particularly due to mismatches between GNU toolchain versions at compilation and deployment. While building `tflite_runtime` from source is an option, it adds unnecessary complexity for users who simply want to run their models.

To improve the user experience and streamline model execution, I've implemented the following changes:

1. **Prioritize TensorFlow Interpreter:** The code now attempts to import and utilize the TFLite interpreter included within the full TensorFlow package if available.
2. **Fallback to TFLite Runtime:** If TensorFlow is not installed, the code gracefully falls back to using `tflite_runtime`.
3. **Nox Testing:** I've added a `noxfile.py` to facilitate testing in environments with different combinations of installed packages (e.g., with and without TensorFlow). This helps ensure compatibility across a wider range of user setups.