### PR TITLE
feat: Add batched processing for long audio files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ docstring-code-format = true
 docstring-code-line-length = 79
 
 [tool.ruff.lint]
+preview = true
 select = ["E4", "E7", "E9", "F", "B", "Q", "I", "D", "DOC"]
 
 [tool.ruff.lint.pydocstyle]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ docstring-code-format = true
 docstring-code-line-length = 79
 
 [tool.ruff.lint]
-select = ["E4", "E7", "E9", "F", "B", "Q", "I", "D"]
+select = ["E4", "E7", "E9", "F", "B", "Q", "I", "D", "DOC"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"

--- a/src/audioclass/batch/base.py
+++ b/src/audioclass/batch/base.py
@@ -382,7 +382,7 @@ def recordings_from_dataframe(
         path = Path(row[path_col])  # type: ignore
         recorded_on = row.get(recorded_on_col)
         tags = [
-            data.Tag(key=col, value=row[col])  # type: ignore
+            data.Tag(term=data.term_from_key(col), value=row[col])  # type: ignore
             for col in additional_cols
         ]
         recording = data.Recording.from_file(

--- a/src/audioclass/batch/tensorflow.py
+++ b/src/audioclass/batch/tensorflow.py
@@ -65,4 +65,8 @@ class TFDatasetIterator(BaseIterator):
         )
 
         for batch_data, (frame, index) in dataset.as_numpy_iterator():  # type: ignore
-            yield batch_data, [self.recordings[int(i)] for i in index], frame
+            yield (
+                batch_data,
+                [self.recordings[int(i)] for i in index[:, 0]],
+                frame,
+            )

--- a/src/audioclass/models/base.py
+++ b/src/audioclass/models/base.py
@@ -82,7 +82,7 @@ class ClipClassificationModel(ABC):
     tags: List[data.Tag]
     """The list of tags that the model can predict."""
 
-    batch_size: int = 32
+    batch_size: int = 8
     """The maximum number of framces to process in each batch."""
 
     @abstractmethod

--- a/src/audioclass/models/base.py
+++ b/src/audioclass/models/base.py
@@ -22,6 +22,7 @@ from audioclass.postprocess import (
     convert_to_predicted_tags_list,
 )
 from audioclass.preprocess import load_clip
+from audioclass.utils import batched
 
 __all__ = [
     "ModelOutput",
@@ -80,6 +81,9 @@ class ClipClassificationModel(ABC):
 
     tags: List[data.Tag]
     """The list of tags that the model can predict."""
+
+    batch_size: int = 32
+    """The maximum number of framces to process in each batch."""
 
     @abstractmethod
     def process_array(self, array: np.ndarray) -> ModelOutput:
@@ -223,7 +227,16 @@ class ClipClassificationModel(ABC):
             samplerate=self.samplerate,
             buffer_size=self.input_samples,
         )
-        class_probs, features = self.process_array(array)
+
+        class_probs = []
+        features = []
+        for batch in batched(array, self.batch_size):
+            probs, feats = self.process_array(batch)
+            class_probs.append(probs)
+            features.append(feats)
+
+        class_probs = np.concatenate(class_probs)
+        features = np.concatenate(features)
 
         if fmt == "soundevent":
             return self._convert_to_soundevent(clip, class_probs, features)

--- a/src/audioclass/models/birdnet.py
+++ b/src/audioclass/models/birdnet.py
@@ -169,6 +169,11 @@ def get_signature(interpreter: Interpreter) -> Signature:
     -------
     Signature
         The signature of the BirdNET model.
+
+    Raises
+    ------
+    ValueError
+        If the model signature does not match the expected format.
     """
     input_details = interpreter.get_input_details()
     output_details = interpreter.get_output_details()

--- a/src/audioclass/models/birdnet.py
+++ b/src/audioclass/models/birdnet.py
@@ -79,6 +79,7 @@ class BirdNET(TFLiteModel):
         samplerate: int = SAMPLERATE,
         name: str = "BirdNET",
         common_name: bool = False,
+        batch_size: int = 8,
     ) -> "BirdNET":
         """Load a BirdNET model from a file or URL.
 
@@ -104,6 +105,8 @@ class BirdNET(TFLiteModel):
         common_name
             Whether to use common names for bird species instead of scientific
             names. Defaults to False.
+        batch_size
+            The number of samples to process in each batch. Defaults to 8.
 
         Returns
         -------
@@ -121,6 +124,7 @@ class BirdNET(TFLiteModel):
             confidence_threshold=confidence_threshold,
             samplerate=samplerate,
             name=name,
+            batch_size=batch_size,
         )
 
 

--- a/src/audioclass/models/birdnet_analyzer.py
+++ b/src/audioclass/models/birdnet_analyzer.py
@@ -50,6 +50,8 @@ class BirdNETAnalyzer(TensorflowModel):
         confidence_threshold: float = DEFAULT_THRESHOLD,
         samplerate: int = SAMPLERATE,
         name: str = "BirdNET",
+        common_name: bool = False,
+        batch_size: int = 8,
     ):
         """Load a BirdNET model from a saved model directory.
 
@@ -71,7 +73,7 @@ class BirdNETAnalyzer(TensorflowModel):
         BirdNETAnalyzer
             An instance of the BirdNET model.
         """
-        tags = load_tags(tags_url)
+        tags = load_tags(tags_url, common_name=common_name)
         model = tf.saved_model.load(model_url)
 
         @tf.function(
@@ -101,6 +103,7 @@ class BirdNETAnalyzer(TensorflowModel):
             confidence_threshold=confidence_threshold,
             samplerate=samplerate,
             name=name,
+            batch_size=batch_size,
         )
 
 

--- a/src/audioclass/models/perch.py
+++ b/src/audioclass/models/perch.py
@@ -62,21 +62,28 @@ class Perch(TensorflowModel):
         confidence_threshold: float = DEFAULT_THRESHOLD,
         samplerate: int = SAMPLERATE,
         name: str = "Perch",
+        batch_size: int = 8,
     ):
         """Load a Perch model from a URL.
 
         Parameters
         ----------
         model_url
-            The URL of the TensorFlow Hub model. Defaults to the official Perch model URL.
+            The URL of the TensorFlow Hub model. Defaults to the official Perch
+            model URL.
         tags_url
-            The URL or path to the file containing the labels. Defaults to the tags file included in the package.
+            The URL or path to the file containing the labels. Defaults to the
+            tags file included in the package.
         confidence_threshold
-            The minimum confidence threshold for making predictions. Defaults to `DEFAULT_THRESHOLD`.
+            The minimum confidence threshold for making predictions. Defaults
+            to `DEFAULT_THRESHOLD`.
         samplerate
-            The sample rate of the audio data expected by the model (in Hz). Defaults to `SAMPLERATE`.
+            The sample rate of the audio data expected by the model (in Hz).
+            Defaults to `SAMPLERATE`.
         name
             The name of the model. Defaults to "Perch".
+        batch_size
+            The batch size used for processing audio data. Defaults to 8.
 
         Returns
         -------
@@ -94,6 +101,7 @@ class Perch(TensorflowModel):
             confidence_threshold=confidence_threshold,
             samplerate=samplerate,
             name=name,
+            batch_size=batch_size,
         )
 
 

--- a/src/audioclass/models/perch.py
+++ b/src/audioclass/models/perch.py
@@ -110,6 +110,13 @@ def get_signature(callable: Callable) -> Signature:
     -------
     Signature
         The signature of the Perch model.
+
+    Raises
+    ------
+    ValueError
+        If the model does not have exactly one input tensor, if the input
+        tensor does not have 2 dimensions, or if the model does not have
+        exactly two output tensors.
     """
     function_type = callable.function_type
     parameters = function_type.parameters

--- a/src/audioclass/models/tensorflow.py
+++ b/src/audioclass/models/tensorflow.py
@@ -66,7 +66,7 @@ class TensorflowModel(ClipClassificationModel):
         samplerate: int,
         name: str,
         logits: bool = True,
-        batch_size: int = 32,
+        batch_size: int = 8,
     ):
         """Initialize a TensorflowModel.
 
@@ -89,7 +89,7 @@ class TensorflowModel(ClipClassificationModel):
             Defaults to True.
         batch_size
             The maximum number of frames to process in each batch.
-            Defaults to 32.
+            Defaults to 8.
         """
         self.callable = callable
         self.tags = tags

--- a/src/audioclass/models/tensorflow.py
+++ b/src/audioclass/models/tensorflow.py
@@ -66,6 +66,7 @@ class TensorflowModel(ClipClassificationModel):
         samplerate: int,
         name: str,
         logits: bool = True,
+        batch_size: int = 32,
     ):
         """Initialize a TensorflowModel.
 
@@ -86,6 +87,9 @@ class TensorflowModel(ClipClassificationModel):
         logits
             Whether the model outputs logits (True) or probabilities (False).
             Defaults to True.
+        batch_size
+            The maximum number of frames to process in each batch.
+            Defaults to 32.
         """
         self.callable = callable
         self.tags = tags
@@ -96,6 +100,7 @@ class TensorflowModel(ClipClassificationModel):
         self.input_samples = signature.input_length
         self.num_classes = len(tags)
         self.logits = logits
+        self.batch_size = batch_size
 
         _validate_signature(self.callable, self.signature)
 
@@ -113,6 +118,18 @@ class TensorflowModel(ClipClassificationModel):
         ModelOutput
             A `ModelOutput` object containing the class probabilities and
             extracted features.
+
+        Note
+        ----
+        This is a low-level method that requires manual batching of
+        the input audio array. If you prefer a higher-level
+        interface that handles batching automatically, consider
+        using `process_file`, `process_recording`, or `process_clip`
+        instead.
+
+        Be aware that passing an array with a large batch size may
+        exceed available device memory and cause the process to
+        crash.
         """
         return process_array(
             self.callable,

--- a/src/audioclass/models/tflite.py
+++ b/src/audioclass/models/tflite.py
@@ -73,6 +73,7 @@ class TFLiteModel(ClipClassificationModel):
         samplerate: int,
         name: str,
         logits: bool = True,
+        batch_size: int = 32,
     ):
         """Initialize a TFLiteModel.
 
@@ -93,6 +94,9 @@ class TFLiteModel(ClipClassificationModel):
         logits
             Whether the model outputs logits (True) or probabilities (False).
             Defaults to True.
+        batch_size
+            The maximum number of frames to process in each batch. Defaults to
+            32.
         """
         self.interpreter = interpreter
         self.tags = tags
@@ -103,6 +107,7 @@ class TFLiteModel(ClipClassificationModel):
         self.input_samples = signature.input_length
         self.num_classes = len(tags)
         self.logits = logits
+        self.batch_size = batch_size
 
         _validate_signature(self.interpreter, self.signature)
 
@@ -120,6 +125,18 @@ class TFLiteModel(ClipClassificationModel):
         ModelOutput
             A `ModelOutput` object containing the class probabilities and
             extracted features.
+
+        Note
+        ----
+        This is a low-level method that requires manual batching of
+        the input audio array. If you prefer a higher-level
+        interface that handles batching automatically, consider
+        using `process_file`, `process_recording`, or `process_clip`
+        instead.
+
+        Be aware that passing an array with a large batch size may
+        exceed available device memory and cause the process to
+        crash.
         """
         return process_array(
             self.interpreter,

--- a/src/audioclass/models/tflite.py
+++ b/src/audioclass/models/tflite.py
@@ -73,7 +73,7 @@ class TFLiteModel(ClipClassificationModel):
         samplerate: int,
         name: str,
         logits: bool = True,
-        batch_size: int = 32,
+        batch_size: int = 8,
     ):
         """Initialize a TFLiteModel.
 
@@ -96,7 +96,7 @@ class TFLiteModel(ClipClassificationModel):
             Defaults to True.
         batch_size
             The maximum number of frames to process in each batch. Defaults to
-            32.
+            8.
         """
         self.interpreter = interpreter
         self.tags = tags

--- a/src/audioclass/preprocess.py
+++ b/src/audioclass/preprocess.py
@@ -178,6 +178,11 @@ def stack_array(
     np.ndarray
         A 2D array of shape (num_buffers, buffer_size) containing the stacked
         buffers.
+
+    Raises
+    ------
+    ValueError
+        If the input array has more than one dimension.
     """
     if arr.ndim != 1:
         raise ValueError(

--- a/src/audioclass/utils.py
+++ b/src/audioclass/utils.py
@@ -191,6 +191,12 @@ def batched(
     ------
     batch : np.ndarray
         The next batch of data from the array.
+
+    Raises
+    ------
+    ValueError
+        If n is less than 1 or if strict is True and the final batch is shorter
+        than n.
     """
     if n < 1:
         raise ValueError("n must be at least one")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,8 +8,14 @@ import pytest
 import soundfile as sf
 
 
-def random_string():
-    """Generate a random string of fixed length."""
+def random_string() -> str:
+    """Generate a random string of fixed length.
+
+    Returns
+    -------
+    str
+        A random string of 10 characters.
+    """
     options = string.ascii_uppercase + string.digits
     return "".join(random.choice(options) for _ in range(10))
 
@@ -31,7 +37,13 @@ def write_random_wave(
 
 @pytest.fixture
 def random_wav_factory(tmp_path: Path):
-    """Produce a random wav file."""
+    """Produce a random audio file.
+
+    Returns
+    -------
+    Callable
+        A function that creates a random audio file.
+    """
 
     def wav_factory(
         path: Optional[Path] = None,
@@ -42,6 +54,31 @@ def random_wav_factory(tmp_path: Path):
         fmt: str = "WAV",
         subtype: Optional[str] = None,
     ) -> Path:
+        """Create a random audio file.
+
+        Parameters
+        ----------
+        path
+            The path to save the audio file. If None, a temporary path will be
+            created.
+        samplerate
+            The sample rate of the audio file.
+        duration
+            The duration of the audio file in seconds.
+        channels
+            The number of channels in the audio file.
+        bit_depth
+            The number of bits per sample.
+        fmt
+            The format of the audio file.
+        subtype
+            The subtype of the audio file.
+
+        Returns
+        -------
+        Path
+            The path to the saved audio file.
+        """
         if path is None:
             path = tmp_path / (random_string() + ".wav")
 

--- a/tests/test_models/test_birdnet.py
+++ b/tests/test_models/test_birdnet.py
@@ -99,3 +99,11 @@ def test_birdnet_can_process_recording_with_metadata(random_wav_factory):
     assert "latitude" in clip_predictions
     assert "longitude" in clip_predictions
     assert "recorded_on" in clip_predictions
+
+
+@pytest.mark.tflite
+def test_birdnet_can_process_a_long_recording(random_wav_factory):
+    model = BirdNET.load()
+    path = random_wav_factory(duration=150)
+    predictions = model.process_file(path)
+    assert isinstance(predictions, list)

--- a/uv.lock
+++ b/uv.lock
@@ -48,7 +48,7 @@ wheels = [
 
 [[package]]
 name = "audioclass"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "netcdf4" },
@@ -567,7 +567,7 @@ name = "importlib-metadata"
 version = "8.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.11'" },
+    { name = "zipp", marker = "python_full_version < '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/12/33e59336dca5be0c398a7482335911a33aa0e20776128f038019f1a95f1b/importlib_metadata-8.5.0.tar.gz", hash = "sha256:71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7", size = 55304 }
 wheels = [


### PR DESCRIPTION
Currently, processing long audio files with audioclass can lead to memory overload due to large batch sizes. This PR introduces a mechanism to perform batched processing of audio frames, preventing memory issues and improving stability.

A new batch_size parameter has been added to the base model. This parameter controls the maximum number of frames processed in each batch. By default, it's set to 8, but users can adjust it during model instantiation to optimize for their specific needs and hardware limitations.

This batched processing is automatically applied when using model.process_file, model.process_recording, and model.process_clip. For advanced use cases, the existing model.process_array method remains unchanged, allowing users to bypass the batching mechanism if necessary.