### PR TITLE
fix: Prevent iterator failure by skipping files that fail to load

### DIFF
--- a/src/audioclass/batch/tensorflow.py
+++ b/src/audioclass/batch/tensorflow.py
@@ -52,6 +52,7 @@ class TFDatasetIterator(BaseIterator):
                 name="load_recording",
                 num_parallel_calls=tf.data.AUTOTUNE,
             )
+            .ignore_errors()
             .enumerate()
             .flat_map(
                 lambda ind, arr: tfdata.Dataset.zip(


### PR DESCRIPTION
This PR improves the experience in audioclass when using TF dataset iterators to iterate over recordings. Before, the iteration would fail as soon as a single data loading error was encountered. Here we include the minimal changes needed to ignore those errors and skip the files that could not be loaded. 