### PR TITLE
feat: ignore errors on dir scan

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ docstring-code-line-length = 79
 [tool.ruff.lint]
 preview = true
 select = ["E4", "E7", "E9", "F", "B", "Q", "I", "D", "DOC"]
+ignore = ["DOC502"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"

--- a/src/audioclass/batch/base.py
+++ b/src/audioclass/batch/base.py
@@ -275,7 +275,10 @@ class BaseIterator(ABC):
         )
 
 
-def recordings_from_files(files: List[Path]) -> List[data.Recording]:
+def recordings_from_files(
+    files: List[Path],
+    ignore_errors: bool = True,
+) -> List[data.Recording]:
     """Create a list of `Recording` objects from a list of file paths.
 
     Parameters
@@ -288,9 +291,18 @@ def recordings_from_files(files: List[Path]) -> List[data.Recording]:
     List[data.Recording]
         A list of `Recording` objects corresponding to the input files.
     """
-    return [
-        data.Recording.from_file(file, compute_hash=False) for file in files
-    ]
+    recordings = []
+
+    for path in files:
+        try:
+            recording = data.Recording.from_file(path, compute_hash=False)
+            recordings.append(recording)
+        except Exception as e:
+            if not ignore_errors:
+                raise e
+            continue
+
+    return recordings
 
 
 def recordings_from_directory(

--- a/src/audioclass/batch/base.py
+++ b/src/audioclass/batch/base.py
@@ -281,15 +281,29 @@ def recordings_from_files(
 ) -> List[data.Recording]:
     """Create a list of `Recording` objects from a list of file paths.
 
+    This function iterates through a list of file paths, creating a
+    `soundevent.data.Recording` object for each file. It can optionally
+    ignore errors that occur during file processing.
+
     Parameters
     ----------
     files
-        A list of paths to audio files.
+        A list of `pathlib.Path` objects pointing to audio files.
+    ignore_errors
+        If True, any errors encountered while creating a `Recording` from a
+        file will be ignored, and the file will be skipped. If False, any
+        error will be raised. Defaults to True.
 
     Returns
     -------
     List[data.Recording]
-        A list of `Recording` objects corresponding to the input files.
+        A list of `Recording` objects created from the provided files.
+
+    Raises
+    ------
+    Exception
+        If `ignore_errors` is False and an error occurs while processing a
+        file.
     """
     recordings = []
 

--- a/tests/test_batch/test_base.py
+++ b/tests/test_batch/test_base.py
@@ -43,6 +43,16 @@ def test_can_run_get_recordings_from_files(
     assert len(recordings) == len(file_list)
 
 
+def test_recordings_from_directory_skips_empty_files(
+    file_list: List[Path],
+    audio_dir: Path,
+):
+    (audio_dir / "empty_audio.wav").touch()
+
+    recordings = recordings_from_directory(audio_dir)
+    assert len(recordings) == len(file_list)
+
+
 def test_can_get_all_audio_files_in_dir(
     random_wav_factory,
     tmp_path: Path,

--- a/uv.lock
+++ b/uv.lock
@@ -49,7 +49,7 @@ wheels = [
 
 [[package]]
 name = "audioclass"
-version = "0.2.2"
+version = "0.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "netcdf4" },
@@ -1253,15 +1253,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.386"
+version = "1.1.403"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/92/50/1a57054b5585fa72a93a6244c1b4b5639f8f7a1cc60b2e807cc67da8f0bc/pyright-1.1.386.tar.gz", hash = "sha256:8e9975e34948ba5f8e07792a9c9d2bdceb2c6c0b61742b068d2229ca2bc4a9d9", size = 21949, upload-time = "2024-10-23T06:50:50.989Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/f6/35f885264ff08c960b23d1542038d8da86971c5d8c955cfab195a4f672d7/pyright-1.1.403.tar.gz", hash = "sha256:3ab69b9f41c67fb5bbb4d7a36243256f0d549ed3608678d381d5f51863921104", size = 3913526, upload-time = "2025-07-09T07:15:52.882Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/68/47fd6b3ffa27c99d7e0c866c618f07784b8806712059049daa492ca7e526/pyright-1.1.386-py3-none-any.whl", hash = "sha256:7071ac495593b2258ccdbbf495f1a5c0e5f27951f6b429bed4e8b296eb5cd21d", size = 18577, upload-time = "2024-10-23T06:50:49.369Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b6/b04e5c2f41a5ccad74a1a4759da41adb20b4bc9d59a5e08d29ba60084d07/pyright-1.1.403-py3-none-any.whl", hash = "sha256:c0eeca5aa76cbef3fcc271259bbd785753c7ad7bcac99a9162b4c4c7daed23b3", size = 5684504, upload-time = "2025-07-09T07:15:50.958Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR addresses an issue where iterator creation fails due to unreadable audio files. The changes ensure that such files are ignored, preventing crashes and improving robustness.